### PR TITLE
Fixed version matching in extconf.rb.

### DIFF
--- a/ext/shadow/extconf.rb
+++ b/ext/shadow/extconf.rb
@@ -6,7 +6,7 @@
 
 require 'mkmf'
 
-$CFLAGS = RUBY_VERSION =~ /1\.8/ ? '-DRUBY18' : ''
+$CFLAGS = RUBY_VERSION =~ /^1\.8/ ? '-DRUBY18' : ''
 
 if( ! (ok = have_library("shadow","getspent")) )
   ok = have_func("getspent")

--- a/lib/libshadow.rb
+++ b/lib/libshadow.rb
@@ -1,5 +1,5 @@
 require "shadow"
 
 module Shadow
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/libshadow.gemspec
+++ b/libshadow.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.summary          = %q{shadow.h}
   s.description      = %q{Ruby C Extension for shadow access}
   s.homepage         = %q{http://github.com/railsmachine/libshadow}
-  s.version          = '1.0.1'
+  s.version          = '1.0.2'
   s.authors          = ["Jesse Newland", "Lee Jones"]
   s.email            = %q{ops@railsmachine.com}
 


### PR DESCRIPTION
A regex near the beginning of extconf.rb was intended to determine if the Ruby version was 1.8.x. However, it was written in such a way that it would also match Ruby 2.1.8. In this case, the extension would fail to compile because the wrong headers were being used.

The regex has now been modified to be more specific to prevent this issue. Caveat: although I have tested this against Ruby 2.1.8, I do not have a Ruby 1.8.x environment to test against to confirm that it works there.
