### PR TITLE
Fix `rb_struct_define` terminator

### DIFF
--- a/ext/shadow/shadow.c
+++ b/ext/shadow/shadow.c
@@ -266,10 +266,10 @@ Init_shadow()
   rb_sPasswdEntry = rb_struct_define("PasswdEntry",
 				     "sp_namp","sp_pwdp","sp_lstchg",
 				     "sp_min","sp_max","sp_warn",
-				     "sp_inact","sp_expire","sp_flag",0);
+				     "sp_inact","sp_expire","sp_flag",NULL);
   rb_sGroupEntry = rb_struct_define("GroupEntry",
 				    "sg_name","sg_passwd",
-				    "sg_adm","sg_mem",0);
+				    "sg_adm","sg_mem",NULL);
 
   rb_mShadow = rb_define_module("Shadow");
   rb_eFileLock = rb_define_class_under(rb_mShadow,"FileLock",rb_eException);


### PR DESCRIPTION
`rb_struct_define` expects `char*` list.
`0` is just an `int`, and it is smaller than a pointer on platforms where `sizeof(char*) > sizeof(int)`.
This bug caused a segfault (https://bugs.ruby-lang.org/issues/12450).
